### PR TITLE
Use SmallGroupsAddLayer where SmallGrp offers it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,7 @@ This file describes changes in the sglppow package.
 
 # Unreleased
 
-  - Register both layers with the small groups library through
-    `SmallGroupsAddLayer` where `SmallGrp` offers it; older `SmallGrp` is
-    still supported, and only there do `layer_3hoch8`, `layer_phoch7`,
-    `pos_3hoch8` and `pos_phoch7` hold slot numbers.
+  - If available, use the `SmallGroupsAddLayer` function provided by `SmallGrp`
 
 # 2.5 (2026-07-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 This file describes changes in the sglppow package.
 
+# Unreleased
+
+  - Register both layers with the small groups library through
+    `SmallGroupsAddLayer` where `SmallGrp` offers it, instead of filling its
+    arrays by hand. The old route is kept for older `SmallGrp`, where
+    `layer_3hoch8`, `layer_phoch7`, `pos_3hoch8` and `pos_phoch7` still hold
+    slot numbers; with the new one they stay `false`.
+
 # 2.5 (2026-07-28)
 
   - Require GAP >= 4.10 and declare `smallgrp` as an explicit dependency

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,9 @@ This file describes changes in the sglppow package.
 # Unreleased
 
   - Register both layers with the small groups library through
-    `SmallGroupsAddLayer` where `SmallGrp` offers it, instead of filling its
-    arrays by hand. The old route is kept for older `SmallGrp`, where
-    `layer_3hoch8`, `layer_phoch7`, `pos_3hoch8` and `pos_phoch7` still hold
-    slot numbers; with the new one they stay `false`.
+    `SmallGroupsAddLayer` where `SmallGrp` offers it; older `SmallGrp` is
+    still supported, and only there do `layer_3hoch8`, `layer_phoch7`,
+    `pos_3hoch8` and `pos_phoch7` hold slot numbers.
 
 # 2.5 (2026-07-28)
 

--- a/lib/3hoch8/sgl-6561.g
+++ b/lib/3hoch8/sgl-6561.g
@@ -1,7 +1,104 @@
+# the orders we cover, and how many groups we have of each
+BindGlobal("SGLPPOW_AVAILABLE_3HOCH8", function( size )
+    if size <> 3^8 then
+        return fail;
+    fi;
+    return rec( number := 1396077 );
+end);
+
+# Method for SmallGroup(size, i):
+BindGlobal("SGLPPOW_GROUP_3HOCH8", function( size, i, inforec )
+    local l, j, k;
+
+    if i > inforec.number then
+        Error("there are just ",inforec.number," groups of order ",size );
+    fi;
+
+    l := [ 1, 58, 486, 1343, 330, 9, 4, 216747, 40521, 2163, 24, 23361,
+           494666, 22343, 51, 578478, 14796, 80, 566, 39, 10, 1 ];
+
+    j := 1;
+    k := i;
+    while k > l[j] do
+        k := k-l[j];
+        j := j+1;
+    od;
+
+    if not IsBound( SMALL_GROUP_LIB[ 6561 ] ) then
+        SMALL_GROUP_LIB[ 6561 ] := [];
+    fi;
+
+    if not IsBound( SMALL_GROUP_LIB[ 6561 ][j] ) then
+        if j = 1 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank1class8" ); # 1
+        elif j = 2 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank2class3" ); # 2
+        elif j = 3 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank2class4" ); # 3
+        elif j = 4 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank2class5" ); # 4
+        elif j = 5 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank2class6" ); # 5
+        elif j = 6 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank2class7" ); # 6
+        elif j = 7 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank3class2" ); # 7
+        elif j = 8 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank3class3" ); # 8
+        elif j = 9 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank3class4" ); # 9
+        elif j = 10 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank3class5" ); # 10
+        elif j = 11 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank3class6" ); # 11
+        elif j = 12 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank4class2" ); # 12
+        elif j = 13 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank4class3" ); # 13
+        elif j = 14 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank4class4" ); # 14
+        elif j = 15 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank4class5" ); # 15
+        elif j = 16 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank5class2" ); # 16
+        elif j = 17 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank5class3" ); # 17
+        elif j = 18 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank5class4" ); # 18
+        elif j = 19 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank6class2" ); # 19
+        elif j = 20 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank6class3" ); # 20
+        elif j = 21 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank7class2" ); # 21
+        elif j = 22 then
+            ReadPackage( "sglppow", "lib/3hoch8/rank8class1" ); # 22
+        fi;
+    fi;
+
+    return PcGroupCode( SMALL_GROUP_LIB[6561][j][k], size );
+end);
+
+#
+# hook us up on the layer level
+#
+
+if IsBound(SmallGroupsAddLayer) then
+
+# SmallGrp 1.7 and up: describe the layer and let SmallGrp place it
+SmallGroupsAddLayer( rec(
+    name := "SglPPow 3^8",
+    available := SGLPPOW_AVAILABLE_3HOCH8,
+    group := SGLPPOW_GROUP_3HOCH8,
+    information := SGLPPOW_INFO ) );
+
+else
+
+# SmallGrp before 1.7: claim the slots and fill the arrays by hand
+
 # Get the next available "layer" id (the built-in library
 # consists of 11 layers, but other packages may already have
 # added further layers).
-
 layer_3hoch8 := Length(SMALL_AVAILABLE_FUNCS) + 1;
 
 # Determine where to add our new lookup functions
@@ -13,25 +110,22 @@ pos_3hoch8 := Maximum(List([
         SELECT_SMALL_GROUPS_FUNCS,
     ], Length)) + 1;
 
-#
-# hook us up on the layer level
-#
-
 # meta data on small groups data we provide
 SMALL_AVAILABLE_FUNCS[layer_3hoch8] := function( size )
-    if size = 3^8 then
-        return rec (
-            lib := layer_3hoch8,
-            func := pos_3hoch8,
-            number := 1396077);
+    local r;
+    r := SGLPPOW_AVAILABLE_3HOCH8( size );
+    if r = fail then
+        return fail;
     fi;
-    return fail;
+    r.lib := layer_3hoch8;
+    r.func := pos_3hoch8;
+    return r;
 end;
 
 # meta data on IdGroup functionality we provide
 ID_AVAILABLE_FUNCS[layer_3hoch8] := function( size )
     # Three possible implementations:
-    
+
     # 1. No IdGroup functionality at all:
     return fail;
 
@@ -46,77 +140,7 @@ ID_AVAILABLE_FUNCS[layer_3hoch8] := function( size )
 end;
 
 # Method for SmallGroup(size, i):
-SMALL_GROUP_FUNCS[ pos_3hoch8 ] := function( size, i, inforec )
-    local l, j, k;
-
-    if i > inforec.number then 
-        Error("there are just ",inforec.number," groups of order ",size );
-    fi;
-
-    l := [ 1, 58, 486, 1343, 330, 9, 4, 216747, 40521, 2163, 24, 23361, 
-           494666, 22343, 51, 578478, 14796, 80, 566, 39, 10, 1 ];
-  
-    j := 1;
-    k := i;
-    while k > l[j] do
-        k := k-l[j];
-        j := j+1;
-    od;
-
-    if not IsBound( SMALL_GROUP_LIB[ 6561 ] ) then 
-        SMALL_GROUP_LIB[ 6561 ] := [];
-    fi;
-
-    if not IsBound( SMALL_GROUP_LIB[ 6561 ][j] ) then 
-        if j = 1 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank1class8" ); # 1
-        elif j = 2 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank2class3" ); # 2
-        elif j = 3 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank2class4" ); # 3
-        elif j = 4 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank2class5" ); # 4
-        elif j = 5 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank2class6" ); # 5
-        elif j = 6 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank2class7" ); # 6
-        elif j = 7 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank3class2" ); # 7
-        elif j = 8 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank3class3" ); # 8
-        elif j = 9 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank3class4" ); # 9
-        elif j = 10 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank3class5" ); # 10
-        elif j = 11 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank3class6" ); # 11
-        elif j = 12 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank4class2" ); # 12
-        elif j = 13 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank4class3" ); # 13
-        elif j = 14 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank4class4" ); # 14
-        elif j = 15 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank4class5" ); # 15
-        elif j = 16 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank5class2" ); # 16
-        elif j = 17 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank5class3" ); # 17
-        elif j = 18 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank5class4" ); # 18
-        elif j = 19 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank6class2" ); # 19
-        elif j = 20 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank6class3" ); # 20
-        elif j = 21 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank7class2" ); # 21
-        elif j = 22 then 
-            ReadPackage( "sglppow", "lib/3hoch8/rank8class1" ); # 22
-        fi;
-    fi;
-
-    return PcGroupCode( SMALL_GROUP_LIB[6561][j][k], size );
-end;
+SMALL_GROUP_FUNCS[ pos_3hoch8 ] := SGLPPOW_GROUP_3HOCH8;
 
 # Method which selects a subset of all those groups with
 # a certain combination of properties.
@@ -125,9 +149,6 @@ end;
 # the abelian groups, and which also knows that all groups
 # of order p^n are nilpotent.
 SELECT_SMALL_GROUPS_FUNCS[ pos_3hoch8 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
-#SELECT_SMALL_GROUPS_FUNCS[ pos_3hoch8 ] := function( funcs, vals, inforec, all, id )
-#    Error("TODO");
-#end;
 
 # Optional: Method for IdGroup(size, i).
 #ID_GROUP_FUNCS[ pos_3hoch8 ] := function( G, inforec )
@@ -135,7 +156,6 @@ SELECT_SMALL_GROUPS_FUNCS[ pos_3hoch8 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
 #end;
 
 # Method for SmallGroupsInformation(size):
-SMALL_GROUPS_INFORMATION[ pos_3hoch8 ] := function( size, inforec, num )
-    Print( " \n");
-    Print( "This database was created by Michael Vaughan-Lee (2014).\n");
-end;
+SMALL_GROUPS_INFORMATION[ pos_3hoch8 ] := SGLPPOW_INFO;
+
+fi;

--- a/lib/phoch7/sgl-p7.g
+++ b/lib/phoch7/sgl-p7.g
@@ -1,3 +1,94 @@
+# the orders we cover, and how many groups we have of each
+BindGlobal("SGLPPOW_AVAILABLE_PHOCH7", function( size )
+    local f, p, n;
+    f := Factors(size);
+    p := f[1];
+    n := Length(f);
+    if Length(Set(f)) <> 1 or p <= 11 or n <> 7 then
+        return fail;
+    fi;
+    return rec (
+        p := p,
+        n := n,
+        number := 3 * p ^ 5 + 12 * p ^ 4 + 44 * p ^ 3 + 170 * p ^ 2
+               # + 707 * p + 2
+                + 707 * p + 2455
+                + (4 * p ^ 2 + 44 * p + 291) * Gcd((p-1), 3 )
+                + (p ^ 2 + 19 * p + 135) * Gcd((p-1), 4 )
+                + (3 * p + 31) * Gcd((p-1), 5 )
+                + 4 * Gcd((p-1), 7 )
+                + 5 * Gcd((p-1), 8 ) + Gcd((p-1), 9 )
+       );
+end);
+
+# Method for SmallGroup(size, i):
+BindGlobal("SGLPPOW_GROUP_PHOCH7", function( size, i, inforec )
+    local p, l, j, k, L, F;
+    p := inforec.p;
+
+    if i > inforec.number then
+        Error("there are just ",inforec.number," groups of order ",size );
+    fi;
+
+    if not IsBound( SMALL_GROUP_LIB_P7[p] ) then
+        SMALL_GROUP_LIB_P7[p] := [];
+        SMALL_GROUP_NUM_P7[p] := [];
+    fi;
+
+    if not IsBound(SMALL_GROUP_NUM_P7[p][1]) then
+        L := LiePRingByData(7, LIE_DATA[7][1] );
+        l := NumberOfLiePRingsInFamily(L);
+        SMALL_GROUP_NUM_P7[p][1] := EvaluatePorcPoly(l, p);
+    fi;
+
+    j := 1;
+    k := i;
+    while k > SMALL_GROUP_NUM_P7[p][j] do
+        k := k-SMALL_GROUP_NUM_P7[p][j];
+        j := j+1;
+        if not IsBound(SMALL_GROUP_NUM_P7[p][j]) then
+            L := LiePRingByData(7, LIE_DATA[7][j] );
+            l := NumberOfLiePRingsInFamily(L);
+            SMALL_GROUP_NUM_P7[p][j] := EvaluatePorcPoly(l, p);
+        fi;
+        if not IsInt(SMALL_GROUP_NUM_P7[p][j]) then
+            L := LiePRingByData(7, LIE_DATA[7][j]);
+            SMALL_GROUP_LIB_P7[p][j] := LiePRingsInFamily(L, p, "code");
+            SMALL_GROUP_NUM_P7[p][j] := Length(SMALL_GROUP_LIB_P7[p][j]);
+        fi;
+    od;
+
+    if IsBound( SMALL_GROUP_LIB_P7[p][j] ) then
+        return PcGroupCode( SMALL_GROUP_LIB_P7[p][j][k], size );
+    fi;
+
+    if SMALL_GROUP_NUM_P7[p][j] > p then
+        Print("constructing a batch of ",SMALL_GROUP_NUM_P7[p][j]," groups ");
+        Print("... this may take a while \n");
+    fi;
+
+    L := LiePRingByData(7, LIE_DATA[7][j]);
+    SMALL_GROUP_LIB_P7[p][j] := LiePRingsInFamily(L, p, "code");
+    return PcGroupCode( SMALL_GROUP_LIB_P7[p][j][k], size );
+end);
+
+#
+# hook us up on the layer level
+#
+
+if IsBound(SmallGroupsAddLayer) then
+
+# SmallGrp 1.7 and up: describe the layer and let SmallGrp place it
+SmallGroupsAddLayer( rec(
+    name := "SglPPow p^7",
+    available := SGLPPOW_AVAILABLE_PHOCH7,
+    group := SGLPPOW_GROUP_PHOCH7,
+    information := SGLPPOW_INFO ) );
+
+else
+
+# SmallGrp before 1.7: claim the slots and fill the arrays by hand
+
 # Get the next available "layer" id (the built-in library
 # consists of 11 layers, but other packages may already have
 # added further layers).
@@ -5,10 +96,6 @@ layer_phoch7 := layer_3hoch8+1;
 
 # Determine where to add our new lookup functions
 pos_phoch7 := pos_3hoch8+1;
-
-#
-# hook us up on the layer level
-#
 
 # need to adjust this, as otherwise an error is produced
 SMALL_AVAILABLE_FUNCS[11] := function( size )
@@ -22,33 +109,20 @@ end;
 
 # meta data on small groups data we provide
 SMALL_AVAILABLE_FUNCS[layer_phoch7] := function( size )
-    local f, p, n;
-    f := Factors(size);
-    p := f[1]; 
-    n := Length(f);
-    if Length(Set(f)) = 1 and p > 11 and n = 7 then 
-        return rec (
-            lib := layer_phoch7,
-            func := pos_phoch7,
-            p := p,
-            n := n,
-            number := 3 * p ^ 5 + 12 * p ^ 4 + 44 * p ^ 3 + 170 * p ^ 2 
-                   # + 707 * p + 2 
-                    + 707 * p + 2455 
-                    + (4 * p ^ 2 + 44 * p + 291) * Gcd((p-1), 3 ) 
-                    + (p ^ 2 + 19 * p + 135) * Gcd((p-1), 4 ) 
-                    + (3 * p + 31) * Gcd((p-1), 5 ) 
-                    + 4 * Gcd((p-1), 7 ) 
-                    + 5 * Gcd((p-1), 8 ) + Gcd((p-1), 9 ) 
-           );
+    local r;
+    r := SGLPPOW_AVAILABLE_PHOCH7( size );
+    if r = fail then
+        return fail;
     fi;
-    return fail;
+    r.lib := layer_phoch7;
+    r.func := pos_phoch7;
+    return r;
 end;
 
 # meta data on IdGroup functionality we provide
 ID_AVAILABLE_FUNCS[layer_phoch7] := function( size )
     # Three possible implementations:
-    
+
     # 1. No IdGroup functionality at all:
     return fail;
 
@@ -63,55 +137,7 @@ ID_AVAILABLE_FUNCS[layer_phoch7] := function( size )
 end;
 
 # Method for SmallGroup(size, i):
-SMALL_GROUP_FUNCS[ pos_phoch7 ] := function( size, i, inforec )
-    local p, l, j, k, L, F;
-    p := inforec.p;
-
-    if i > inforec.number then 
-        Error("there are just ",inforec.number," groups of order ",size );
-    fi;
-
-    if not IsBound( SMALL_GROUP_LIB_P7[p] ) then 
-        SMALL_GROUP_LIB_P7[p] := [];
-        SMALL_GROUP_NUM_P7[p] := [];
-    fi;
-
-    if not IsBound(SMALL_GROUP_NUM_P7[p][1]) then 
-        L := LiePRingByData(7, LIE_DATA[7][1] );
-        l := NumberOfLiePRingsInFamily(L);
-        SMALL_GROUP_NUM_P7[p][1] := EvaluatePorcPoly(l, p);
-    fi;
-
-    j := 1;
-    k := i;
-    while k > SMALL_GROUP_NUM_P7[p][j] do
-        k := k-SMALL_GROUP_NUM_P7[p][j];
-        j := j+1;
-        if not IsBound(SMALL_GROUP_NUM_P7[p][j]) then 
-            L := LiePRingByData(7, LIE_DATA[7][j] );
-            l := NumberOfLiePRingsInFamily(L);
-            SMALL_GROUP_NUM_P7[p][j] := EvaluatePorcPoly(l, p);
-        fi;
-        if not IsInt(SMALL_GROUP_NUM_P7[p][j]) then 
-            L := LiePRingByData(7, LIE_DATA[7][j]);
-            SMALL_GROUP_LIB_P7[p][j] := LiePRingsInFamily(L, p, "code");
-            SMALL_GROUP_NUM_P7[p][j] := Length(SMALL_GROUP_LIB_P7[p][j]);
-        fi;
-    od;
-
-    if IsBound( SMALL_GROUP_LIB_P7[p][j] ) then 
-        return PcGroupCode( SMALL_GROUP_LIB_P7[p][j][k], size );
-    fi;
-
-    if SMALL_GROUP_NUM_P7[p][j] > p then 
-        Print("constructing a batch of ",SMALL_GROUP_NUM_P7[p][j]," groups ");
-        Print("... this may take a while \n");
-    fi;
-
-    L := LiePRingByData(7, LIE_DATA[7][j]);
-    SMALL_GROUP_LIB_P7[p][j] := LiePRingsInFamily(L, p, "code");
-    return PcGroupCode( SMALL_GROUP_LIB_P7[p][j][k], size );
-end;
+SMALL_GROUP_FUNCS[ pos_phoch7 ] := SGLPPOW_GROUP_PHOCH7;
 
 # Method which selects a subset of all those groups with
 # a certain combination of properties.
@@ -120,9 +146,6 @@ end;
 # the abelian groups, and which also knows that all groups
 # of order p^n are nilpotent.
 SELECT_SMALL_GROUPS_FUNCS[ pos_phoch7 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
-#SELECT_SMALL_GROUPS_FUNCS[ pos_phoch7 ] := function( funcs, vals, inforec, all, id )
-#    Error("TODO");
-#end;
 
 # Optional: Method for IdGroup(size, i).
 #ID_GROUP_FUNCS[ pos_phoch7 ] := function( G, inforec )
@@ -130,8 +153,6 @@ SELECT_SMALL_GROUPS_FUNCS[ pos_phoch7 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
 #end;
 
 # Method for SmallGroupsInformation(size):
-SMALL_GROUPS_INFORMATION[ pos_phoch7 ] := function( size, inforec, num )
-    Print( " \n");
-    Print( "This database was created by Michael Vaughan-Lee (2014).\n");
-end;
+SMALL_GROUPS_INFORMATION[ pos_phoch7 ] := SGLPPOW_INFO;
 
+fi;

--- a/read.g
+++ b/read.g
@@ -16,6 +16,12 @@ layer_phoch7 := false;
 pos_3hoch8 := false;
 pos_phoch7 := false;
 
+# Method for SmallGroupsInformation(size), used by both our layers
+BindGlobal( "SGLPPOW_INFO", function( size, inforec, num )
+    Print( " \n");
+    Print( "This database was created by Michael Vaughan-Lee (2014).\n");
+end );
+
 ReadPackage( "sglppow", "lib/3hoch8/sgl-6561.g" ); 
 
 if IsPackageMarkedForLoading( "LieRing", "2.2" ) and

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,6 +1,7 @@
 LoadPackage("sglppow");
 exclude := [];
-if layer_phoch7 = false then
+if not IsBound(SGLPPOW_AVAILABLE_PHOCH7) then
+    # lib/phoch7/sgl-p7.g was not read, whichever way we register
     Add(exclude, "order_p_7.tst");
 fi;
 


### PR DESCRIPTION
SmallGrp 1.7 takes a layer as a record and places it itself, so the slot numbers and the array assignments are no longer ours to get right -- nor is the chaining of the p^7 slots off the 3^8 ones. The old route stays for SmallGrp before 1.7, chosen by IsBound.

The parts both routes need are pulled out first: the group construction, the count of the groups of an order, and the message `SmallGroupsInformation` prints, which both layers share and `read.g` now binds once.

The new route omits the patch of `SMALL_AVAILABLE_FUNCS[11]`. SmallGrp's own layer 11 has long returned fail for p > 11, so it only restates what is already there; the old route keeps it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>